### PR TITLE
fix: check malloc returns and return early on failure in BFS module (Issue #11)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,3 +150,11 @@ test-kruskal:
 		./src/devyani/tests/test_kruskal.c \
 		-o ./dist/tests/test_kruskal.exe
 	./dist/tests/test_kruskal.exe
+
+test-malloc-guards:
+	mkdir -p ./dist/tests
+	gcc -I./src/sean/tests/unity \
+		./src/sean/tests/unity/unity.c \
+		./src/sean/tests/test_malloc_guards.c \
+		-o ./dist/tests/test_malloc_guards.exe
+	./dist/tests/test_malloc_guards.exe

--- a/src/sean/tests/test_malloc_guards.c
+++ b/src/sean/tests/test_malloc_guards.c
@@ -1,0 +1,139 @@
+/* test_malloc_guards.c
+ *
+ * Unity regression tests for Issue #11: malloc returns unchecked in the
+ * BFS (sean) module.
+ *
+ * Most critically, insert_edge in src/sean/wasm/graph.c checks for a NULL
+ * return from malloc but then falls through and dereferences it anyway:
+ *
+ *   new_edge = (edge *)malloc(sizeof(edge));
+ *   if (new_edge == NULL) { printf("Malloc failed!"); }  // no return
+ *   new_edge->destination = destination;                 // NULL deref -> SIGSEGV
+ *
+ * Malloc injection technique
+ * --------------------------
+ * test_mock_malloc() is defined BEFORE the `#define malloc test_mock_malloc`
+ * directive so its own body still calls the real stdlib malloc.  All malloc()
+ * calls inside the subsequently-included graph.c are transparently redirected
+ * through the injector, enabling controlled single-call failure without any
+ * linker tricks or platform-specific hooks.
+ *
+ * Test ordering:
+ *   test 1 – insert_edge baseline correctness (passes before and after fix)
+ *   test 2 – insert_edge with malloc failure: must return cleanly, not crash
+ *             (process SIGSEGV before fix; PASS after fix — TDD red→green)
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "unity.h"
+
+/* ---- malloc injection -------------------------------------------------- */
+
+static int g_malloc_fail_countdown = -1; /* -1 = never fail, 0 = fail next */
+
+/* IMPORTANT: defined BEFORE #define malloc test_mock_malloc so that the
+ * `malloc(size)` call in this body still refers to the real stdlib malloc. */
+static void *test_mock_malloc(size_t size)
+{
+    if (g_malloc_fail_countdown == 0)
+        return NULL;
+    if (g_malloc_fail_countdown > 0)
+        g_malloc_fail_countdown--;
+    return malloc(size); /* real stdlib malloc — #define not yet active */
+}
+
+/* Redirect all malloc() calls in included .c files through the injector. */
+#define malloc test_mock_malloc
+#include "../wasm/graph.c"
+#undef malloc /* restore for test helper code below */
+
+/* ---- helpers ----------------------------------------------------------- */
+
+static void free_graph_edges(graph *g)
+{
+    for (int32_t v = 0; v <= MAXV; v++)
+    {
+        edge *e = g->edges[v];
+        while (e != NULL)
+        {
+            edge *next = e->next;
+            free(e);
+            e = next;
+        }
+    }
+}
+
+/* ---- Unity lifecycle --------------------------------------------------- */
+
+void setUp(void)    { g_malloc_fail_countdown = -1; }
+void tearDown(void) {}
+
+/* ================================================================
+ * Test 1 – insert_edge baseline correctness
+ *
+ * Confirms the normal (malloc succeeds) path works correctly.
+ * Passes before and after the fix.
+ * ================================================================ */
+void test_insert_edge_succeeds_normally(void)
+{
+    graph *g = malloc(sizeof(graph)); /* real malloc — #define was undef'd */
+    initialize_graph(g, true);
+
+    insert_edge(g, 1, 2, true);
+
+    TEST_ASSERT_EQUAL_INT_MESSAGE(1, g->number_edges,
+        "insert_edge must increment number_edges on success");
+    TEST_ASSERT_NOT_NULL_MESSAGE(g->edges[1],
+        "insert_edge must populate edges[source] on success");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(2, g->edges[1]->destination,
+        "inserted edge must record correct destination");
+
+    free_graph_edges(g);
+    free(g);
+}
+
+/* ================================================================
+ * Test 2 – insert_edge must return cleanly on malloc failure (Issue #11)
+ *
+ * Bug:  after the NULL check there is no `return`, so the code falls
+ *       through to `new_edge->destination = destination` — a guaranteed
+ *       NULL dereference that terminates the process with SIGSEGV.
+ * Fix:  add `return;` immediately after the fprintf(stderr, ...) call.
+ *
+ * Before fix: process crashes (SIGSEGV) — confirming the bug.
+ * After fix:  insert_edge returns early; graph state is unchanged.
+ *
+ * NOTE: this test is placed last so that test 1 results are reported
+ * even when the unfixed code kills the process here.
+ * ================================================================ */
+void test_insert_edge_malloc_failure_is_safe(void)
+{
+    graph *g = malloc(sizeof(graph)); /* real malloc, countdown=-1 */
+    initialize_graph(g, true);        /* no malloc inside */
+
+    g_malloc_fail_countdown = 0;      /* next malloc() call → NULL */
+    insert_edge(g, 1, 2, true);       /* internally calls test_mock_malloc → NULL */
+
+    /* If we reach these assertions the fix is in place. */
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0, g->number_edges,
+        "Issue #11: insert_edge must not modify graph when malloc fails");
+    TEST_ASSERT_NULL_MESSAGE(g->edges[1],
+        "Issue #11: insert_edge must not dereference the NULL new_edge pointer");
+
+    free(g); /* no edges allocated — simple free is sufficient */
+}
+
+/* ================================================================ */
+int main(void)
+{
+    setbuf(stdout, NULL); /* unbuffer stdout so test-1 results survive a crash in test-2 */
+    UNITY_BEGIN();
+    RUN_TEST(test_insert_edge_succeeds_normally);
+    RUN_TEST(test_insert_edge_malloc_failure_is_safe); /* last: crashes before fix */
+    return UNITY_END();
+}

--- a/src/sean/wasm/bfs.c
+++ b/src/sean/wasm/bfs.c
@@ -15,6 +15,11 @@ void bfs(graph *g, int32_t start, bool is_discovered[MAXV + 1], int32_t has_pare
     if (g->is_CSR)
     {
         uint8_t *level = malloc((g->number_vertices + 1) * sizeof(uint8_t));
+        if (level == NULL)
+        {
+            fprintf(stderr, "bfs: level malloc failed\n");
+            return;
+        }
         memset(level, UINT8_MAX, (g->number_vertices + 1) * sizeof(uint8_t));
         uint8_t current_level = 0;
         int32_t neighbor_count = 0;
@@ -32,6 +37,12 @@ void bfs(graph *g, int32_t start, bool is_discovered[MAXV + 1], int32_t has_pare
                 {
                     neighbor_count = getDegree(g, current_vertex);
                     int32_t *neighbors = malloc(getDegree(g, current_vertex) * sizeof(int32_t));
+                    if (neighbors == NULL)
+                    {
+                        fprintf(stderr, "bfs: neighbors malloc failed\n");
+                        free(level);
+                        return;
+                    }
                     getNeighbors(g, current_vertex, neighbors);
 
                     for (int32_t i = 0; i < neighbor_count; i++)
@@ -60,6 +71,11 @@ void bfs(graph *g, int32_t start, bool is_discovered[MAXV + 1], int32_t has_pare
 
         // Initialize queue
         q = malloc(sizeof(queue));
+        if (q == NULL)
+        {
+            fprintf(stderr, "bfs: queue malloc failed\n");
+            return;
+        }
         reset(q, false);
 
         // Add start to queue

--- a/src/sean/wasm/graph.c
+++ b/src/sean/wasm/graph.c
@@ -68,7 +68,8 @@ void insert_edge(graph *g, int32_t source, int32_t destination, bool is_directed
     new_edge = (edge *)malloc(sizeof(edge)); /* allocate edge storage */
     if (new_edge == NULL)
     {
-        printf("Malloc failed!");
+        fprintf(stderr, "insert_edge: malloc failed\n");
+        return; /* Issue #11: must not fall through to dereference NULL */
     }
 
     new_edge->destination = destination;
@@ -92,6 +93,11 @@ void insert_edge(graph *g, int32_t source, int32_t destination, bool is_directed
 void build_csr(graph *g)
 {
     g->IA = malloc((g->number_vertices + 2) * sizeof(int32_t));
+    if (g->IA == NULL)
+    {
+        fprintf(stderr, "build_csr: IA malloc failed\n");
+        return;
+    }
 
     // Poison slot 0 so any accidental 0-based indexing crashes fast (graph is 1-indexed)
     g->IA[0] = 0xDEAD;
@@ -99,6 +105,13 @@ void build_csr(graph *g)
     g->IA[1] = 0;
     // number_edges counts undirected pairs once; multiply by 2 for both directions
     g->JA = malloc((g->number_edges * 2) * sizeof(int32_t));
+    if (g->JA == NULL)
+    {
+        fprintf(stderr, "build_csr: JA malloc failed\n");
+        free(g->IA);
+        g->IA = NULL;
+        return;
+    }
     int32_t edge_idx = 0;
     for (int32_t current_vertex = 1; current_vertex <= g->number_vertices; current_vertex++)
     {

--- a/src/sean/wasm/main.c
+++ b/src/sean/wasm/main.c
@@ -17,6 +17,11 @@ void createGraph()
 {
     printf("Start Create Graph\n");
     myGraph = malloc(sizeof(graph));
+    if (myGraph == NULL)
+    {
+        fprintf(stderr, "createGraph: malloc failed\n");
+        return;
+    }
     initialize_graph(myGraph, false);
     printf("Graph Created!\n");
 }


### PR DESCRIPTION
## Summary

- `graph.c` `insert_edge`: had a NULL check but **no `return`**, falling through to dereference the NULL pointer — guaranteed SIGSEGV under allocation pressure
- `graph.c` `build_csr`: `IA` and `JA` allocations unchecked
- `bfs.c` CSR path: `level` and per-vertex `neighbors` buffers unchecked
- `bfs.c` adjacency-list path: `queue` allocation unchecked
- `main.c` `createGraph`: `myGraph` allocation unchecked

All error paths now use `fprintf(stderr, ...)` + `return` rather than `printf` + fall-through.

## Malloc injection technique

Tests use a preprocessor-level injector — `test_mock_malloc()` is defined **before** `#define malloc test_mock_malloc`, so its own body still references the real `stdlib` `malloc`. All `malloc()` calls inside the subsequently-included `graph.c` are redirected through the injector, enabling controlled single-call failure without linker tricks or platform-specific hooks.

## Test plan

- [ ] `make test-malloc-guards` — 2/2 pass
  - test 1: `insert_edge` baseline correctness
  - test 2: `insert_edge` with injected malloc failure returns cleanly (no crash)
- [ ] `make test-sean` — 5/5 pass (no regressions)
- [ ] `make test-bfs` — 2/2 pass (no regressions)

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)