### PR TITLE
fix: free all matrix allocations in Strassen module (Issue #12)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,14 @@ test-kruskal:
 		-o ./dist/tests/test_kruskal.exe
 	./dist/tests/test_kruskal.exe
 
+test-strassen:
+	mkdir -p ./dist/tests
+	gcc -I./src/sean/tests/unity \
+		./src/sean/tests/unity/unity.c \
+		./src/alvaro/tests/test_strassen.c \
+		-o ./dist/tests/test_strassen.exe
+	./dist/tests/test_strassen.exe
+
 test-malloc-guards:
 	mkdir -p ./dist/tests
 	gcc -I./src/sean/tests/unity \

--- a/src/alvaro/tests/test_strassen.c
+++ b/src/alvaro/tests/test_strassen.c
@@ -1,0 +1,145 @@
+/* test_strassen.c
+ *
+ * Unity regression tests for Issue #12: pervasive memory leaks and unchecked
+ * malloc in src/alvaro/wasm/main.c (Strassen matrix multiplication).
+ *
+ * Bugs:
+ *   - multiplyStrassens allocates 8 sub-matrices (a11..a22, b11..b22) and
+ *     8 intermediate product matrices (via recursive calls + add) but frees
+ *     none of them.  The compound expressions like
+ *       c11 = add(multiplyStrassens(...), multiplyStrassens(...), half);
+ *     discard the inner return values — those matrices are permanently leaked.
+ *   - matrixMultiplication allocates m1, m2, m3 and returns without freeing
+ *     any of them.
+ *   - initializeMatrix / initializeEmptyMatrix do not check malloc returns.
+ *
+ * Malloc/free injection technique
+ * ---------------------------------
+ * count_malloc() and count_free() are defined BEFORE the #define directives so
+ * their bodies still call the real stdlib allocators.  freeMatrix() — a new
+ * helper added by the fix — is defined AFTER #define free count_free so that
+ * its free() calls are counted.  All allocations inside the subsequently-
+ * included main.c are then transparently tracked.
+ *
+ * Test ordering:
+ *   test 1 – multiplyStrassens correctness baseline (passes before and after)
+ *   test 2 – matrixMultiplication must free every allocation it makes
+ *             (FAIL before fix: alloc_count != free_count; PASS after fix)
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <time.h>
+
+#include "unity.h"
+
+/* ---- allocation counters ------------------------------------------ */
+
+static int alloc_count = 0;
+static int free_count  = 0;
+
+/* Defined BEFORE #define malloc/free so their own bodies use real allocators */
+static void *count_malloc(size_t size)
+{
+    alloc_count++;
+    return malloc(size); /* real stdlib malloc — #define not yet active */
+}
+
+static void count_free(void *ptr)
+{
+    if (ptr != NULL)
+        free_count++;
+    free(ptr); /* real stdlib free — #define not yet active */
+}
+
+/* ---- malloc/free injection ----------------------------------------- */
+
+#define malloc count_malloc
+#define free   count_free
+
+/* freeMatrix is defined HERE (after #define free) so its free() calls are
+ * counted.  The #define HAVE_FREE_MATRIX guard prevents main.c from
+ * re-defining the same function when it is included below.             */
+static void freeMatrix(int **m, int size)
+{
+    if (m == NULL)
+        return;
+    for (int i = 0; i < size; i++)
+        free(m[i]); /* counted */
+    free(m);        /* counted */
+}
+#define HAVE_FREE_MATRIX 1
+
+#include "../wasm/main.c"
+
+#undef malloc
+#undef free
+
+/* ---- Unity lifecycle ---------------------------------------------- */
+
+void setUp(void)    { alloc_count = 0; free_count = 0; }
+void tearDown(void) {}
+
+/* ================================================================
+ * Test 1 – multiplyStrassens correctness baseline
+ *
+ * For an NxN matrix of all-2s multiplied by an NxN matrix of all-3s,
+ * every result element must equal N * (2*3) = 6N.
+ * Uses the base-case multiply() path (N=4 < 256 threshold).
+ * Passes before and after the fix.
+ * ================================================================ */
+void test_multiplyStrassens_produces_correct_result(void)
+{
+    int N = 4;
+    int **m1     = initializeMatrix(N, 2);
+    int **m2     = initializeMatrix(N, 3);
+    int **result = multiplyStrassens(m1, m2, N);
+
+    TEST_ASSERT_NOT_NULL_MESSAGE(result, "multiplyStrassens must return non-NULL");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(N * 6, result[0][0],
+        "result[0][0] must equal N*2*3 = 24");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(N * 6, result[N - 1][N - 1],
+        "result[N-1][N-1] must equal N*2*3 = 24");
+
+    freeMatrix(m1,     N);
+    freeMatrix(m2,     N);
+    freeMatrix(result, N);
+}
+
+/* ================================================================
+ * Test 2 – matrixMultiplication must not leak memory (Issue #12)
+ *
+ * Bug:  matrixMultiplication allocates m1, m2, m3 and returns without
+ *       freeing any of them.  multiplyStrassens similarly leaks all 8
+ *       sub-matrix allocations and all 8 intermediate product matrices.
+ * Fix:  add freeMatrix() helper; free every intermediate and result
+ *       matrix before returning.
+ *
+ * Before fix: alloc_count > 0, free_count == 0 → TEST FAILS
+ * After  fix: alloc_count == free_count         → TEST PASSES
+ *
+ * NOTE: this test is placed last so test-1 results are visible even
+ * if an unfixed crash occurs (though here the bug is a silent leak,
+ * not a crash).
+ * ================================================================ */
+void test_matrixMultiplication_frees_all_matrices(void)
+{
+    /* alloc_count and free_count are 0 from setUp() */
+    matrixMultiplication(4); /* small size — uses base-case multiply() */
+
+    TEST_ASSERT_GREATER_THAN_INT_MESSAGE(0, alloc_count,
+        "sanity: matrixMultiplication must allocate at least one matrix");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(alloc_count, free_count,
+        "Issue #12: matrixMultiplication leaks memory "
+        "(expected alloc_count == free_count; before fix free_count == 0)");
+}
+
+/* ================================================================ */
+int main(void)
+{
+    setbuf(stdout, NULL); /* unbuffered so results survive any crash */
+    UNITY_BEGIN();
+    RUN_TEST(test_multiplyStrassens_produces_correct_result);
+    RUN_TEST(test_matrixMultiplication_frees_all_matrices);
+    return UNITY_END();
+}

--- a/src/alvaro/wasm/main.c
+++ b/src/alvaro/wasm/main.c
@@ -5,13 +5,25 @@
 
 int **initializeMatrix(int size, int value)
 {
-    int **matrix;
     int i, j;
 
-    matrix = malloc(size * sizeof *matrix);
+    int **matrix = malloc(size * sizeof *matrix);
+    if (matrix == NULL)
+    {
+        fprintf(stderr, "initializeMatrix: malloc failed\n");
+        return NULL;
+    }
     for (i = 0; i < size; i++)
     {
         matrix[i] = malloc(size * sizeof *matrix[i]);
+        if (matrix[i] == NULL)
+        {
+            fprintf(stderr, "initializeMatrix: row malloc failed\n");
+            for (int k = 0; k < i; k++)
+                free(matrix[k]);
+            free(matrix);
+            return NULL;
+        }
     }
 
     for (i = 0; i < size; i++)
@@ -27,16 +39,43 @@ int **initializeMatrix(int size, int value)
 
 int **initializeEmptyMatrix(int size)
 {
-    int **matrix;
-    int i, j;
+    int i;
 
-    matrix = malloc(size * sizeof *matrix);
+    int **matrix = malloc(size * sizeof *matrix);
+    if (matrix == NULL)
+    {
+        fprintf(stderr, "initializeEmptyMatrix: malloc failed\n");
+        return NULL;
+    }
     for (i = 0; i < size; i++)
     {
         matrix[i] = malloc(size * sizeof *matrix[i]);
+        if (matrix[i] == NULL)
+        {
+            fprintf(stderr, "initializeEmptyMatrix: row malloc failed\n");
+            for (int k = 0; k < i; k++)
+                free(matrix[k]);
+            free(matrix);
+            return NULL;
+        }
     }
     return matrix;
 }
+
+/* Issue #12: helper to free a size x size matrix allocated by
+ * initializeMatrix / initializeEmptyMatrix.
+ * Protected by HAVE_FREE_MATRIX so the test file can pre-define it
+ * (with counted free calls) without causing a duplicate symbol. */
+#ifndef HAVE_FREE_MATRIX
+void freeMatrix(int **m, int size)
+{
+    if (m == NULL)
+        return;
+    for (int i = 0; i < size; i++)
+        free(m[i]);
+    free(m);
+}
+#endif
 
 void display(int **matrix, int size)
 {
@@ -137,52 +176,68 @@ int **getSuperMatrix(int **c11, int **c12, int **c21, int **c22, int size)
 
 int **multiplyStrassens(int **a, int **b, int size)
 {
-
     if (size < 256)
         return multiply(a, b, size);
 
-    int i, j, k;
+    int half = size / 2;
 
-    int **a11;
-    int **a12;
-    int **a21;
-    int **a22;
+    /* Partition A and B into quadrants */
+    int **a11 = getSubMatrix(a, size, 1, 1);
+    int **a12 = getSubMatrix(a, size, 1, 2);
+    int **a21 = getSubMatrix(a, size, 2, 1);
+    int **a22 = getSubMatrix(a, size, 2, 2);
 
-    a11 = getSubMatrix(a, size, 1, 1);
-    a12 = getSubMatrix(a, size, 1, 2);
-    a21 = getSubMatrix(a, size, 2, 1);
-    a22 = getSubMatrix(a, size, 2, 2);
+    int **b11 = getSubMatrix(b, size, 1, 1);
+    int **b12 = getSubMatrix(b, size, 1, 2);
+    int **b21 = getSubMatrix(b, size, 2, 1);
+    int **b22 = getSubMatrix(b, size, 2, 2);
 
-    int **b11;
-    int **b12;
-    int **b21;
-    int **b22;
+    /* Compute result quadrants; free intermediate products immediately.
+     * Issue #12: the original code used compound expressions like
+     *   c11 = add(multiplyStrassens(...), multiplyStrassens(...), half)
+     * which made both inner return values unreachable and permanently leaked. */
 
-    b11 = getSubMatrix(b, size, 1, 1);
-    b12 = getSubMatrix(b, size, 1, 2);
-    b21 = getSubMatrix(b, size, 2, 1);
-    b22 = getSubMatrix(b, size, 2, 2);
+    int **prod1, **prod2;
 
-    int **c11;
-    int **c12;
-    int **c21;
-    int **c22;
+    prod1 = multiplyStrassens(a11, b11, half);
+    prod2 = multiplyStrassens(a12, b21, half);
+    int **c11 = add(prod1, prod2, half);
+    freeMatrix(prod1, half);
+    freeMatrix(prod2, half);
 
-    c11 = add(multiplyStrassens(a11, b11, size / 2), multiplyStrassens(a12, b21, size / 2), size / 2);
-    c12 = add(multiplyStrassens(a11, b12, size / 2), multiplyStrassens(a12, b22, size / 2), size / 2);
-    c21 = add(multiplyStrassens(a21, b11, size / 2), multiplyStrassens(a22, b21, size / 2), size / 2);
-    c22 = add(multiplyStrassens(a21, b12, size / 2), multiplyStrassens(a22, b22, size / 2), size / 2);
+    prod1 = multiplyStrassens(a11, b12, half);
+    prod2 = multiplyStrassens(a12, b22, half);
+    int **c12 = add(prod1, prod2, half);
+    freeMatrix(prod1, half);
+    freeMatrix(prod2, half);
 
-    int **c;
+    prod1 = multiplyStrassens(a21, b11, half);
+    prod2 = multiplyStrassens(a22, b21, half);
+    int **c21 = add(prod1, prod2, half);
+    freeMatrix(prod1, half);
+    freeMatrix(prod2, half);
 
-    c = getSuperMatrix(c11, c12, c21, c22, size / 2);
+    prod1 = multiplyStrassens(a21, b12, half);
+    prod2 = multiplyStrassens(a22, b22, half);
+    int **c22 = add(prod1, prod2, half);
+    freeMatrix(prod1, half);
+    freeMatrix(prod2, half);
+
+    int **c = getSuperMatrix(c11, c12, c21, c22, half);
+
+    /* Free all quadrant matrices now that getSuperMatrix has consumed them */
+    freeMatrix(a11, half); freeMatrix(a12, half);
+    freeMatrix(a21, half); freeMatrix(a22, half);
+    freeMatrix(b11, half); freeMatrix(b12, half);
+    freeMatrix(b21, half); freeMatrix(b22, half);
+    freeMatrix(c11, half); freeMatrix(c12, half);
+    freeMatrix(c21, half); freeMatrix(c22, half);
 
     return c;
 }
 
 void matrixMultiplication(int matrixSize)
 {
-    int y, x;
     double totalTime;
     clock_t start, end;
 
@@ -192,6 +247,12 @@ void matrixMultiplication(int matrixSize)
 
     m1 = initializeMatrix(matrixSize, 2);
     m2 = initializeMatrix(matrixSize, 3);
+    if (m1 == NULL || m2 == NULL)
+    {
+        freeMatrix(m1, matrixSize);
+        freeMatrix(m2, matrixSize);
+        return;
+    }
 
     printf("Multiplication started \n");
     start = clock();
@@ -199,5 +260,10 @@ void matrixMultiplication(int matrixSize)
     end = clock();
     totalTime = ((double)(end - start)) / CLOCKS_PER_SEC;
     printf("Strassens process time for %dx%d matrix multiplication: %f\n", matrixSize, matrixSize, totalTime);
+
+    /* Issue #12: free all three matrices before returning */
+    freeMatrix(m1, matrixSize);
+    freeMatrix(m2, matrixSize);
+    freeMatrix(m3, matrixSize);
     return;
 }


### PR DESCRIPTION
## Summary

- Adds `freeMatrix(int **m, int size)` helper (guarded by `#ifndef HAVE_FREE_MATRIX` so the test file can supply a counted version without duplicate symbols)
- Breaks the compound `add(multiplyStrassens(...), multiplyStrassens(...), half)` expressions into separate statements so each intermediate product matrix can be freed immediately after `add()` consumes it
- Frees all 12 quadrant matrices (`a11`..`b22`, `c11`..`c22`) at the end of `multiplyStrassens` before returning
- Frees `m1`, `m2`, `m3` in `matrixMultiplication` before returning
- Checks every `malloc` in `initializeMatrix` and `initializeEmptyMatrix`; cleans up already-allocated rows if a mid-loop allocation fails

## Root cause

The original code used compound expressions:
```c
c11 = add(multiplyStrassens(a11, b11, half), multiplyStrassens(a12, b21, half), half);
```
The two inner return values were passed directly to `add()` and the pointers were never stored — so they could never be freed. Every recursive level leaked 8 sub-matrices + 8 intermediate products. `matrixMultiplication` leaked `m1`, `m2`, `m3` unconditionally.

## Test plan

- [ ] `make test-strassen` — 2/2 pass
  - test 1: `multiplyStrassens` correctness baseline (`result[i][j] == N*6`)
  - test 2: `matrixMultiplication` `alloc_count == free_count` (no leak)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)