### PR TITLE
fix: guard src/libs copy in build-deps against missing directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ make-dist:
 build-deps: make-dist
 	cp -r ./src/resources ./dist
 	cp ./src/htmlTemplates/index.html ./dist/index.html
-	cp -r ./src/libs ./dist
+	@if [ -d ./src/libs ]; then cp -r ./src/libs ./dist; fi
 
 clean-fibb: 
 	rm -rf ./dist/fibb


### PR DESCRIPTION
Fixes #23

## Summary
- Replace the unconditional `cp -r ./src/libs ./dist` in the `build-deps` Makefile target with a conditional: `@if [ -d ./src/libs ]; then cp -r ./src/libs ./dist; fi`
- `src/libs` does not exist in the repository; the old line caused every `make build`, `make build-sean`, `make build-alvaro`, `make build-devyani`, and `make build-fibb` to fail immediately on a fresh clone

## Test plan
- [ ] `make test-sean` — graph construction unit tests
- [ ] `make test-bfs` — BFS unit tests
- [ ] `make test-kruskal` — Kruskal / Union-Find unit tests
- [ ] `make test-strassen` — Strassen matrix multiplication unit tests
- [ ] `make test-malloc-guards` — malloc failure safety tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)