### PR TITLE
fix: correct findRoot path compression in Union-Find

### DIFF
--- a/src/devyani/wasm/main.c
+++ b/src/devyani/wasm/main.c
@@ -144,11 +144,8 @@ void makeset(int u)
 int findRoot(int u)
 {
     if (parent[u] != u)
-    {
-        u = parent[u];
-        parent[u] = findRoot(u);
-    }
-    return (u);
+        parent[u] = findRoot(parent[u]);
+    return parent[u];
 }
 
 // Returns boolean indicating if union of two disparate sets occured


### PR DESCRIPTION
Fixes #20

## Summary
- Fix the `findRoot` function in [`src/devyani/wasm/main.c`](src/devyani/wasm/main.c) (lines 143–149)
- The old code did `u = parent[u]` before `parent[u] = findRoot(u)`, overwriting the original node index and compressing the wrong node — returning an intermediate ancestor rather than the true root
- Replaced with standard recursive path compression: `parent[u] = findRoot(parent[u]); return parent[u];`

**Before (buggy):**
```c
if (parent[u] != u) {
    u = parent[u];
    parent[u] = findRoot(u);
}
return (u);
```

**After (fixed):**
```c
if (parent[u] != u)
    parent[u] = findRoot(parent[u]);
return parent[u];
```

## Test plan
- [ ] `make test-sean` — graph construction unit tests
- [ ] `make test-bfs` — BFS unit tests
- [ ] `make test-kruskal` — Kruskal / Union-Find unit tests (most directly exercises this fix)
- [ ] `make test-strassen` — Strassen matrix multiplication unit tests
- [ ] `make test-malloc-guards` — malloc failure safety tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)