### PR TITLE
fix: correct enqueue overflow check off-by-one in queue

### DIFF
--- a/src/sean/wasm/queue.c
+++ b/src/sean/wasm/queue.c
@@ -14,7 +14,7 @@ typedef struct queue
 
 void enqueue(int32_t x, queue *q)
 {
-    if (q->end >= MAXV)
+    if (q->end > MAXV)
     {
         printf("Error: Queue is full");
         /* TODO: Implement queue cleanup...*/


### PR DESCRIPTION
Fixes #21

## Summary
- Change `>=` to `>` in the overflow guard in [`src/sean/wasm/queue.c`](src/sean/wasm/queue.c) line 17
- With `end` initialized to 1, the guard `end >= MAXV` blocked the write when `end == MAXV`, even though `data[end-1] = data[MAXV-1]` is a valid slot — limiting the queue to `MAXV-1` items
- Changing to `end > MAXV` allows `end` to reach `MAXV`, filling the last slot, and only blocks when `end` would go out of bounds

**Before:** `if (q->end >= MAXV)`  
**After:** `if (q->end > MAXV)`

## Test plan
- [ ] `make test-sean` — graph construction unit tests
- [ ] `make test-bfs` — BFS unit tests
- [ ] `make test-kruskal` — Kruskal / Union-Find unit tests
- [ ] `make test-strassen` — Strassen matrix multiplication unit tests
- [ ] `make test-malloc-guards` — malloc failure safety tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)