### PR TITLE
fix: add early return in dequeue when queue is empty

### DIFF
--- a/src/sean/wasm/queue.c
+++ b/src/sean/wasm/queue.c
@@ -29,6 +29,7 @@ int32_t dequeue(queue *q)
     if (q->start == q->end - 1)
     {
         printf("Error: Queue is empty\n");
+        return -1;
     }
     int32_t result = q->data[q->start];
     q->start++;


### PR DESCRIPTION
Fixes #22

## Summary
- Add `return -1;` after the error print in `dequeue` in [`src/sean/wasm/queue.c`](src/sean/wasm/queue.c) lines 29–32
- Without the early return, the function fell through, read stale/uninitialized data from `data[q->start]`, returned garbage, and incremented `q->start` past the valid range — corrupting queue state for any subsequent use
- `-1` is a safe sentinel; all callers in the BFS path already guard with `while (len(q) > 0)` so this path is only reachable via a programming error

**Before:**
```c
if (q->start == q->end - 1) {
    printf("Error: Queue is empty\n");
    // falls through — returns garbage
}
```

**After:**
```c
if (q->start == q->end - 1) {
    printf("Error: Queue is empty\n");
    return -1;
}
```

## Test plan
- [ ] `make test-sean` — graph construction unit tests
- [ ] `make test-bfs` — BFS unit tests
- [ ] `make test-kruskal` — Kruskal / Union-Find unit tests
- [ ] `make test-strassen` — Strassen matrix multiplication unit tests
- [ ] `make test-malloc-guards` — malloc failure safety tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)