### PR TITLE
fix: change BFS level array from uint8_t to uint32_t

### DIFF
--- a/src/sean/wasm/bfs.c
+++ b/src/sean/wasm/bfs.c
@@ -1,6 +1,7 @@
 #include <limits.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <stdbool.h>
 
 #include "constants.h"
@@ -14,14 +15,15 @@ void bfs(graph *g, int32_t start, bool is_discovered[MAXV + 1], int32_t has_pare
 {
     if (g->is_CSR)
     {
-        uint8_t *level = malloc((g->number_vertices + 1) * sizeof(uint8_t));
+        uint32_t *level = malloc((g->number_vertices + 1) * sizeof(uint32_t));
         if (level == NULL)
         {
             fprintf(stderr, "bfs: level malloc failed\n");
             return;
         }
-        memset(level, UINT8_MAX, (g->number_vertices + 1) * sizeof(uint8_t));
-        uint8_t current_level = 0;
+        for (int32_t i = 0; i <= g->number_vertices; i++)
+            level[i] = UINT32_MAX;
+        uint32_t current_level = 0;
         int32_t neighbor_count = 0;
         bool should_advance = true;
 
@@ -47,7 +49,7 @@ void bfs(graph *g, int32_t start, bool is_discovered[MAXV + 1], int32_t has_pare
 
                     for (int32_t i = 0; i < neighbor_count; i++)
                     {
-                        if (level[neighbors[i]] == UINT8_MAX)
+                        if (level[neighbors[i]] == UINT32_MAX)
                         {
                             should_advance = true;
                             level[neighbors[i]] = current_level + 1;


### PR DESCRIPTION
## Summary
Change the BFS level/distance array type from `uint8_t` to `uint32_t` in `src/sean/wasm/bfs.c` to prevent silent overflow on graphs deeper than 255 levels. The sentinel value is updated from `UINT8_MAX` to `UINT32_MAX` and the initialisation loop uses an explicit element-by-element fill (since `memset` cannot safely write multi-byte values).

Closes #28