### PR TITLE
fix: guard extractMin() against empty heap

### DIFF
--- a/src/devyani/wasm/main.c
+++ b/src/devyani/wasm/main.c
@@ -79,6 +79,11 @@ void kruskal()
     while (mstEdgeIdx < mstLength)
     {
         heapnode *minWeightEdge = extractMin(h);
+        if (minWeightEdge == NULL)
+        {
+            fprintf(stderr, "kruskal: heap exhausted before MST complete\n");
+            break;
+        }
         // Check to see if this edge connects nodes already connected via MST
         bool didMergeUnionSets = mergeUnionSets(minWeightEdge->src, minWeightEdge->des);
 
@@ -234,6 +239,11 @@ void swap(heapnode **p, heapnode **q) // swap function for swaping ptr to heapno
 
 heapnode *extractMin(heap *h)
 {
+    if (h == NULL || h->currentsize == 0)
+    {
+        fprintf(stderr, "extractMin: heap is empty\n");
+        return NULL;
+    }
     heapnode *minHeapnode, *lastHeapnode;
     minHeapnode = h->edgeheaparray[0]; //topmost node is the minimum
     lastHeapnode = h->edgeheaparray[h->currentsize - 1];


### PR DESCRIPTION
## Summary
Add an empty-heap guard at the top of `extractMin()` in `src/devyani/wasm/main.c` so that calling it on an exhausted heap returns `NULL` (with an error message) instead of reading out-of-bounds memory. The call site in `kruskal()` is also updated to check for `NULL` and break cleanly rather than dereferencing the result unconditionally.

Closes #29