### PR TITLE
ci: add least-privilege permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Unit tests (gcc)


### PR DESCRIPTION
## Summary

- Adds `permissions: contents: read` at the workflow level in `.github/workflows/ci.yml`
- Resolves CodeQL code-scanning alerts #3 and #4 ("Workflow does not contain permissions")

## Why

GitHub Actions workflows inherit broad default token permissions unless explicitly restricted. CodeQL flagged both jobs (`test` at line 10 and `build` at line 18) for not declaring permissions. Since both jobs only need to check out the repository, `contents: read` is the correct minimum — all other token scopes are denied by default.

## Reviewer notes

No functional change to the workflow steps. The `GITHUB_TOKEN` now has only read access to repository contents, which is all `actions/checkout` requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)